### PR TITLE
Add linting & formatting to Pipenv & Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
   - pip install pipenv
-  - pipenv install
+  - pipenv install --dev
 
 script:
   - pipenv run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ install:
   - pip install pipenv
   - pipenv install
 
-script: 
+script:
+  - pipenv run lint
   - pipenv run test

--- a/Pipfile
+++ b/Pipfile
@@ -20,4 +20,5 @@ python_version = "3.6"
 [scripts]
 test = "python -m unittest discover mcm/test test_*.py"
 lint = "flake8"
-format = "autopep8 --diff --recursive . --aggressive --aggressive"
+format = "autopep8 --in-place --recursive . --aggressive --aggressive"
+format-diff = "autopep8 --diff --recursive . --aggressive --aggressive"

--- a/Pipfile
+++ b/Pipfile
@@ -20,3 +20,4 @@ python_version = "3.6"
 [scripts]
 test = "python -m unittest discover mcm/test test_*.py"
 lint = "flake8"
+format = "autopep8 --diff --recursive . --aggressive --aggressive"

--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ python_version = "3.6"
 
 [scripts]
 test = "python -m unittest discover mcm/test test_*.py"
+lint = "flake8"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Michigan Cardiovascular Model (MCM)
 
 This is the broad framework for representing a representative population and modeling individual cardiovascular risk factors, outcomes and cognition.
+
+## Development Quickstart
+This section assumes you have Python 3.6+ with `pip` installed. You will need to install `pipenv` if you haven't already:
+```
+pip install -U pipenv
+```
+
+First, clone this GitHub repository using your method of choice. Then, to create a development virtualenv and install development dependencies, run:
+```
+pipenv install --dev
+```
+
+This project uses `flake8` for linting, `autopep8` for formatting, and `unittest` for testing. Each of these tools have Pipenv scripts for convenience:
+```
+pipenv run lint  # check for flake8 errors
+pipenv run format  # format with autopep8
+pipenv run format-diff  # what-if for `pipenv run format`
+pipenv run test  # run tests
+```

--- a/mcm/ascvd_outcome_model.py
+++ b/mcm/ascvd_outcome_model.py
@@ -10,7 +10,7 @@ class ASCVDOutcomeModel:
     def __init__(self, age, black_race, sbp_x_sbp, sbp, bp_treatment, diabetes, current_smoker,
                  tot_chol_hdl_ratio, age_x_black_race, sbp_x_treatment, sbp_x_black_race,
                  black_race_x_treatment, age_x_sbp, black_race_x_diabetes,
-                 black_race_x_current_smoker,  black_race_x_tot_chol_hdl_ratio,
+                 black_race_x_current_smoker, black_race_x_tot_chol_hdl_ratio,
                  sbp_x_black_race_x_treatment, age_x_sbp_x_black_race, intercept):
 
         self._age = age
@@ -65,4 +65,4 @@ class ASCVDOutcomeModel:
 
     # TODO : need to figure out how to account fo rtime...which may be trikcy
     def get_risk_for_person(self, person, years):
-        return 1/(1+np.exp(-1 * self.calc_linear_predictor(person)))
+        return 1 / (1 + np.exp(-1 * self.calc_linear_predictor(person)))

--- a/mcm/outcome_model_repository.py
+++ b/mcm/outcome_model_repository.py
@@ -15,7 +15,7 @@ class OutcomeModelRepository:
                 sbp_x_treatment=-0.003647, sbp_x_black_race=0.006208,
                 black_race_x_treatment=0.152968, age_x_sbp=-0.000153,
                 black_race_x_diabetes=0.115232,
-                black_race_x_current_smoker=-0.092231,  black_race_x_tot_chol_hdl_ratio=0.070498,
+                black_race_x_current_smoker=-0.092231, black_race_x_tot_chol_hdl_ratio=0.070498,
                 sbp_x_black_race_x_treatment=-0.000173, age_x_sbp_x_black_race=-0.000094,
                 intercept=-12.823110
             ),
@@ -26,7 +26,7 @@ class OutcomeModelRepository:
                 sbp_x_treatment=-0.014207, sbp_x_black_race=0.011609,
                 black_race_x_treatment=-0.119460, age_x_sbp=0.000025,
                 black_race_x_diabetes=-0.077214,
-                black_race_x_current_smoker=-0.226771,  black_race_x_tot_chol_hdl_ratio=-0.117749,
+                black_race_x_current_smoker=-0.226771, black_race_x_tot_chol_hdl_ratio=-0.117749,
                 sbp_x_black_race_x_treatment=0.004190, age_x_sbp_x_black_race=-0.000199,
                 intercept=-11.679980
             ),

--- a/mcm/person.py
+++ b/mcm/person.py
@@ -65,7 +65,7 @@ class Person:
         self._bmi.append(self.get_next_risk_factor("bmi", risk_model_repository))
         self._ldl.append(self.get_next_risk_factor("ldl", risk_model_repository))
         self._trig.append(self.get_next_risk_factor("trig", risk_model_repository))
-        self._age.append(self._age[-1]+1)
+        self._age.append(self._age[-1] + 1)
 
     def advance_outcomes(self):
         # do you have an event?

--- a/mcm/test/test_nhanes_linear_risk_factor_model.py
+++ b/mcm/test/test_nhanes_linear_risk_factor_model.py
@@ -18,12 +18,13 @@ class TestNHANESLinearRiskFactorModel(unittest.TestCase):
         self.assertEqual(expectedSBP, self._test_person._sbp[-1])
 
     def test_upper_bounds(self):
-        highBPPerson = Person(age=75, gender=0, raceEthnicity=1, sbp=500, ldl=90,  trig=150,
+        highBPPerson = Person(age=75, gender=0, raceEthnicity=1, sbp=500, ldl=90, trig=150,
                               dbp=80, a1c=6.5, hdl=50, totChol=210, bmi=22, smokingStatus=1)
         highBPPerson.advance_risk_factors(self._risk_model_repository)
         self.assertEqual(300, highBPPerson._sbp[-1])
 
-        # TODO : write more tests — check the categorical variables and ensure that all parameters are passed in or an error is thrown
+        # TODO : write more tests — check the categorical variables and ensure
+        # that all parameters are passed in or an error is thrown
 
 
 if __name__ == "__main__":

--- a/mcm/test/test_risk_model_repository.py
+++ b/mcm/test/test_risk_model_repository.py
@@ -57,7 +57,7 @@ class TestRiskModelRepository(RiskModelRepository):
                                                               resids=pd.Series(np.zeros(10)))
         self._repository['hdl'] = NHANESLinearRiskFactorModel('hdl', params=params, ses=ses,
                                                               resids=pd.Series(np.zeros(10)))
-        self._repository['totChol'] = NHANESLinearRiskFactorModel('totChol', params=params, ses=ses,
-                                                                  resids=pd.Series(np.zeros(10)))
+        self._repository['totChol'] = NHANESLinearRiskFactorModel(
+            'totChol', params=params, ses=ses, resids=pd.Series(np.zeros(10)))
         self._repository['bmi'] = NHANESLinearRiskFactorModel('bmi', params=params, ses=ses,
                                                               resids=pd.Series(np.zeros(10)))

--- a/mcm/test/test_statsmodel_linear_risk_factor_model.py
+++ b/mcm/test/test_statsmodel_linear_risk_factor_model.py
@@ -75,7 +75,7 @@ class TestStatsModelLinearRiskFactorModel(unittest.TestCase):
         dfMeanAndLag = pd.DataFrame({'age': age,
                                      'sbp': [person._sbp[-1] for person in self.people],
                                      'meanSbp': [np.array(person._sbp).mean() for person in self.people],
-                                     'lagSbp':  [person._sbp[-1] for person in self.people]})
+                                     'lagSbp': [person._sbp[-1] for person in self.people]})
 
         self.meanLagModelResultSM = statsmodel.ols(
             formula="sbp ~ age + meanSbp + lagSbp", data=dfMeanAndLag).fit()
@@ -86,7 +86,7 @@ class TestStatsModelLinearRiskFactorModel(unittest.TestCase):
             self.meanLagModelResultSM.resid.std())
 
     def advancePerson(self, person):
-        person._age.append(person._age[-1]+1)
+        person._age.append(person._age[-1] + 1)
         person._dbp.append(person._dbp[-1])
         person._a1c.append(person._a1c[-1])
         person._hdl.append(person._hdl[-1])

--- a/mcm/test/test_statsmodel_linear_risk_factor_model.py
+++ b/mcm/test/test_statsmodel_linear_risk_factor_model.py
@@ -72,10 +72,12 @@ class TestStatsModelLinearRiskFactorModel(unittest.TestCase):
             self.raceModelResultSM.resid.mean(),
             self.raceModelResultSM.resid.std())
 
-        dfMeanAndLag = pd.DataFrame({'age': age,
-                                     'sbp': [person._sbp[-1] for person in self.people],
-                                     'meanSbp': [np.array(person._sbp).mean() for person in self.people],
-                                     'lagSbp': [person._sbp[-1] for person in self.people]})
+        dfMeanAndLag = pd.DataFrame({
+            'age': age,
+            'sbp': [person._sbp[-1] for person in self.people],
+            'meanSbp': [np.array(person._sbp).mean() for person in self.people],
+            'lagSbp': [person._sbp[-1] for person in self.people],
+        })
 
         self.meanLagModelResultSM = statsmodel.ols(
             formula="sbp ~ age + meanSbp + lagSbp", data=dfMeanAndLag).fit()


### PR DESCRIPTION
This PR:
- adds linting and formatting scripts to Pipfile.
  + `flake8` can now be run with `pipenv run lint`.
  + `autopep8` can be run with:
      * `pipenv run format-diff` to see a diff with the proposed formatting changes without actually making them, or
     * `pipenv run format` to actually make formatting changes to the code.
- adds a lint check in Travis, which will now fail the build if code does not pass `flake8`.
- adds a "Development Quickstart" section to the README that briefly describes how to setup a development environment for this repository.

