### PR TITLE
Don't fail CI build only for lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pipenv install --dev
 
 script:
-  - pipenv run lint
+  - pipenv run lint || (echo -n)
   - pipenv run test


### PR DESCRIPTION
Changes `.travis.yml` so that the build doesn't fail only if the lint fails. Figured that we would want to view lint errors but maybe not block only for formatting.