### PR TITLE
Add sample VSCode settings.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ tags
 
 ### User-added Ignores
 .vscode/*
+!.vscode/workspace-settings.example.json

--- a/.vscode/workspace-settings.example.json
+++ b/.vscode/workspace-settings.example.json
@@ -1,11 +1,15 @@
 {
-    "python.pythonPath": "${/path/to/}python",
+    // Prefix "python.(python|flake8|autopep8)Path" settings with path to program in virtualenv.
+    // Will likely be the path output by running following command from the root of the repository:
+    // echo "$(pipenv --venv)/bin"
+
+    "python.pythonPath": "python",
     "python.linting.enabled": true,
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
-    "python.linting.flake8Path": "${/path/to/}flake8",
+    "python.linting.flake8Path": "flake8",
     "python.formatting.provider": "autopep8",
-    "python.formatting.autopep8Path": "${/path/to/}autopep8",
+    "python.formatting.autopep8Path": "autopep8",
     "python.formatting.autopep8Args": ["--aggressive", "--aggressive"],
     "python.unitTest.unittestEnabled": true,
     "python.unitTest.unittestArgs": ["--start-directory", "./mcm/test", "--pattern", "test_*.py"],

--- a/.vscode/workspace-settings.example.json
+++ b/.vscode/workspace-settings.example.json
@@ -1,0 +1,12 @@
+{
+    "python.pythonPath": "${/path/to/}python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Path": "${/path/to/}flake8",
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Path": "${/path/to/}autopep8",
+    "python.formatting.autopep8Args": ["--aggressive", "--aggressive"],
+    "python.unitTest.unittestEnabled": true,
+    "python.unitTest.unittestArgs": ["--start-directory", "./mcm/test", "--pattern", "test_*.py"],
+}

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ ipython = "*"
 python_version = "3.6"
 
 [scripts]
-test = "python -m unittest discover mcm/test test_*.py"
+test = "python -m unittest discover --start-directory ./mcm/test --pattern test_*.py"
 lint = "flake8"
 format = "autopep8 --in-place --recursive . --aggressive --aggressive"
 format-diff = "autopep8 --diff --recursive . --aggressive --aggressive"


### PR DESCRIPTION
Adds an example `settings.json` file (`workspace-settings.example.json`) for users of VSCode and its Python extension to use as a base. It should help users set up a decent development environment with VS Code much more quickly and easily than before.