### PR TITLE
Add model argument transforms

### DIFF
--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,5 +1,12 @@
 from copy import copy
+from typing import Callable, Dict, Iterable, List, Tuple
+import re
+
 import numpy as np
+
+
+categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
+categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 
 class IndicatorTransform:
@@ -43,3 +50,63 @@ def square_transform(value):
 def base_transform(value):
     """Returns the base (i.e., first) element of the given value."""
     return value[0]
+
+
+def get_argument_transforms(
+    parameter_name: str,
+    max_num_transforms: int = 10,
+) -> Tuple[str, List[Callable]]:
+    trimmed_param_name = parameter_name
+    prop_transforms = []
+    reached_base_case = False
+    for _ in range(max_num_transforms):
+        folded_param_name = trimmed_param_name.casefold()
+        categorical_match = categorical_param_name_regex.match(parameter_name)
+        if categorical_match is not None:
+            expected_prop_name = categorical_match['propname']
+            matching_categorical_value = int(categorical_match['matchingval'])
+            prop_transforms.append(IndicatorTransform(matching_categorical_value))
+            reached_base_case = True
+            break
+        elif folded_param_name.startswith("log"):
+            trimmed_param_name = trimmed_param_name[len("log"):]
+            prop_transforms.append(log_transform)
+        elif folded_param_name.startswith("mean"):
+            trimmed_param_name = trimmed_param_name[len("mean"):]
+            prop_transforms.append(mean_transform)
+        elif folded_param_name.startswith("square"):
+            trimmed_param_name = trimmed_param_name[len("square"):]
+            prop_transforms.append(square_transform)
+        elif folded_param_name.startswith("base"):
+            trimmed_param_name = trimmed_param_name[len("base"):]
+            prop_transforms.append(base_transform)
+        elif folded_param_name.startswith("lag"):
+            trimmed_param_name = trimmed_param_name[len("lag"):]
+            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
+            # no transform: identity
+            reached_base_case = True
+            break
+        else:
+            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
+            # no transform: identity
+            reached_base_case = True
+            break
+    if not reached_base_case:
+        raise RuntimeError(
+            f"Error occurred while parsing parameter name ('{parameter_name}') for model argument"
+            f" transforms: exceeded maximum number of iterations ({max_num_transforms}) without"
+            " reaching a base case.",
+            parameter_name,
+            max_num_transforms,
+        )
+    return (expected_prop_name, reversed(prop_transforms))
+
+
+def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Callable]]:
+    """Return transform functions for each model parameter, if any"""
+    param_transforms = {}
+    for param_name in parameter_names:
+        prop_name, transforms = get_argument_transforms(param_name)
+        if param_name.casefold() != prop_name:
+            param_transforms[param_name] = (prop_name, transforms)
+    return param_transforms

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,0 +1,45 @@
+from copy import copy
+import numpy as np
+
+
+class IndicatorTransform:
+    """
+    Transform that returns 1 if value matches; else 0.
+
+    matching_value should be either a primitive or a `copy`-able container of primitives.
+    """
+
+    def __init__(self, matching_value):
+        self._matching_value = copy(matching_value)
+
+    @property
+    def matching_value(self):
+        return self._matching_value
+
+    def __call__(self, value):
+        return 1 if value == self._matching_value else 0
+
+    def __eq__(self, other):
+        if issubclass(type(other), IndicatorTransform):
+            return self._matching_value == other.matching_value
+        return False
+
+
+def log_transform(value):
+    """Returns the log (one or many) of the given value."""
+    return np.log(value)
+
+
+def mean_transform(value):
+    """Returns the mean of the given value."""
+    return np.array(value).mean()
+
+
+def square_transform(value):
+    """Returns the square (one or many) of the given value."""
+    return value ** 2
+
+
+def base_transform(value):
+    """Returns the base (i.e., first) element of the given value."""
+    return value[0]

--- a/mcm/statsmodel_cox_model.py
+++ b/mcm/statsmodel_cox_model.py
@@ -5,15 +5,9 @@ import numpy as np
 class StatsModelCoxModel(StatsModelLinearRiskFactorModel):
     def __init__(self, regression_model, log_transform=False):
         super(StatsModelCoxModel, self).__init__(regression_model, log_transform)
-
-    # called by superclass...
-    def initialize_model_params(self, regression_model, log_transform):
-        self.parameters = regression_model._coefficients
-        self.standard_errors = regression_model._coefficient_standard_errors
         self.one_year_linear_cumulative_hazard = \
             regression_model._one_year_linear_cumulative_hazard
         self.one_year_quad_cumulative_hazard = regression_model._one_year_quad_cumulative_hazard
-        self.log_transform = log_transform
 
     def get_intercept(self):
         return 0

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -29,16 +29,7 @@ class StatsModelLinearRiskFactorModel:
     def convert_first_letter_to_lower(self, toLower):
         return toLower[:1].lower() + toLower[1:]
 
-    '''
-    This will apply an order of operations to the elements of the mdoel name. So, meanLogLagSbp
-    would take lagSBP, log it and take the mean. If the order of operations for the first elements
-    matters,they'll be appleid in order of which they are listed...
-    '''
-
-    # luciana tag...
-    # profiling wise...this is where we're getting killed. 
-    # the solution seems to be to cache this logic in some way. the first time through, figure out the series of manimpuations, subsequently
-    # apply those manipulations — i just dont' see an easy way to do that. it can clearly be done...but, tis going to make my head bleed.
+   # TODO: cache prop name -> transform order
     def get_modified_parameter_for_person(self, name, person):
         if name.startswith("log"):
             name = self.convert_first_letter_to_lower(name[len("log"):])
@@ -52,7 +43,6 @@ class StatsModelLinearRiskFactorModel:
         elif name.startswith("base"):
             name = self.convert_first_letter_to_lower(name[len("base"):])
             return getattr(person, "_" + name)[0]
-        # just strip lag prefixes
         elif name.startswith("lag"):
             name = self.convert_first_letter_to_lower(name[len("lag"):])
             return getattr(person, "_" + name)

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -76,11 +76,6 @@ class StatsModelLinearRiskFactorModel:
             scale=self.residual_standard_deviation,
             size=1)[0]
 
-    def strip_categorical_name(self, name):
-        stripped_name = "_" + name[:name.index("[")]
-        stripped_value = int(name[name.index("[T.") + len("[T."): name.index("]")])
-        return (stripped_name, stripped_value)
-
     def get_intercept(self):
         return self.parameters['Intercept']
 

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -65,13 +65,6 @@ class StatsModelLinearRiskFactorModel:
             scale=self.residual_standard_deviation,
             size=1)[0]
 
-    def get_modified_attribute_for_parameter_from_person(self, name, person):
-        returnParam = self.get_modified_parameter_for_person(name, person)
-        if not isinstance(returnParam, list) and not isinstance(returnParam, np.ndarray):
-            return returnParam
-        else:
-            return returnParam[-1]
-
     def strip_categorical_name(self, name):
         stripped_name = "_" + name[:name.index("[")]
         stripped_value = int(name[name.index("[T.") + len("[T."): name.index("]")])

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -26,9 +26,11 @@ def get_argument_transforms(parameter_name: str) -> Tuple[str, List[Callable]]:
         return (prop_name, transforms + [lambda v: v[0]])
     elif folded_param_name.startswith("lag"):
         trimmed_param_name = parameter_name[len("lag"):]
-        return (trimmed_param_name, [])  # identity: no transformation
+        expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
+        return (expected_prop_name, [])  # identity: no transformation
     else:
-        return (parameter_name, [])  # identity: no transformation
+        expected_prop_name = parameter_name[0].casefold() + parameter_name[1:]
+        return (expected_prop_name, [])  # identity: no transformation
 
 
 def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Callable]]:

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -68,38 +68,6 @@ def get_argument_transforms(
     return (expected_prop_name, reversed(prop_transforms))
 
 
-def get_argument_transforms_recursive(parameter_name: str) -> Tuple[str, List[Callable]]:
-    folded_param_name = parameter_name.casefold()
-    categorical_match = categorical_param_name_regex.match(parameter_name)
-    if categorical_match is not None:
-        prop_name = categorical_match['propname']
-        matching_categorical_value = int(categorical_match['matchingval'])
-        return (prop_name, [lambda v: 1 if v == matching_categorical_value else 0])
-    elif folded_param_name.startswith("log"):
-        trimmed_param_name = parameter_name[len("log"):]
-        prop_name, transforms = get_argument_transforms_recursive(trimmed_param_name)
-        return (prop_name, transforms + [lambda v: np.log(v)])
-    elif folded_param_name.startswith("mean"):
-        trimmed_param_name = parameter_name[len("mean"):]
-        prop_name, transforms = get_argument_transforms_recursive(trimmed_param_name)
-        return (prop_name, transforms + [lambda v: np.array(v).mean()])
-    elif folded_param_name.startswith("square"):
-        trimmed_param_name = parameter_name[len("square"):]
-        prop_name, transforms = get_argument_transforms_recursive(trimmed_param_name)
-        return (prop_name, transforms + [lambda v: v ** 2])
-    elif folded_param_name.startswith("base"):
-        trimmed_param_name = parameter_name[len("base"):]
-        prop_name, transforms = get_argument_transforms_recursive(trimmed_param_name)
-        return (prop_name, transforms + [lambda v: v[0]])
-    elif folded_param_name.startswith("lag"):
-        trimmed_param_name = parameter_name[len("lag"):]
-        expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
-        return (expected_prop_name, [])  # identity: no transformation
-    else:
-        expected_prop_name = parameter_name[0].casefold() + parameter_name[1:]
-        return (expected_prop_name, [])  # identity: no transformation
-
-
 def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Callable]]:
     """Return transform functions for each model parameter, if any"""
     param_transforms = {}

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -6,11 +6,7 @@ import numpy as np
 
 
 class StatsModelLinearRiskFactorModel:
-
     def __init__(self, regression_model, log_transform=False):
-        self.initialize_model_params(regression_model, log_transform)
-
-    def initialize_model_params(self, regression_model, log_transform):
         self.parameters = regression_model._coefficients
         self.standard_errors = regression_model._coefficient_standard_errors
         self.residual_mean = regression_model._residual_mean

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -1,14 +1,11 @@
 from copy import copy
 from functools import reduce
 from typing import Callable, Dict, Iterable, List, Tuple
-import numpy as np
 import re
+import numpy as np
 
 # TODO: this class needs to be renamed. its no longer interfacing with statsmodel
 # conceptually, what it does now is bridge the regression model and the person
-
-categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
-categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 
 class IndicatorTransform:
@@ -54,9 +51,12 @@ def base_transform(value):
     return value[0]
 
 
+categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
+categorical_param_name_regex = re.compile(categorical_param_name_pattern)
+
 def get_argument_transforms(
     parameter_name: str,
-    max_num_transforms: int = 10
+    max_num_transforms: int = 10,
 ) -> Tuple[str, List[Callable]]:
     trimmed_param_name = parameter_name
     prop_transforms = []

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -54,6 +54,7 @@ def base_transform(value):
 categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
 categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
+
 def get_argument_transforms(
     parameter_name: str,
     max_num_transforms: int = 10,

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -1,54 +1,17 @@
-from copy import copy
 from functools import reduce
 from typing import Callable, Dict, Iterable, List, Tuple
 import re
 import numpy as np
+from mcm.model_argument_transform import (
+    base_transform,
+    IndicatorTransform,
+    log_transform,
+    mean_transform,
+    square_transform,
+)
 
 # TODO: this class needs to be renamed. its no longer interfacing with statsmodel
 # conceptually, what it does now is bridge the regression model and the person
-
-
-class IndicatorTransform:
-    """
-    Transform that returns 1 if value matches; else 0.
-
-    matching_value should be either a primitive or a `copy`-able container of primitives.
-    """
-
-    def __init__(self, matching_value):
-        self._matching_value = copy(matching_value)
-
-    @property
-    def matching_value(self):
-        return self._matching_value
-
-    def __call__(self, value):
-        return 1 if value == self._matching_value else 0
-
-    def __eq__(self, other):
-        if issubclass(type(other), IndicatorTransform):
-            return self._matching_value == other.matching_value
-        return False
-
-
-def log_transform(value):
-    """Returns the log (one or many) of the given value."""
-    return np.log(value)
-
-
-def mean_transform(value):
-    """Returns the mean of the given value."""
-    return np.array(value).mean()
-
-
-def square_transform(value):
-    """Returns the square (one or many) of the given value."""
-    return value ** 2
-
-
-def base_transform(value):
-    """Returns the base (i.e., first) element of the given value."""
-    return value[0]
 
 
 categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -45,12 +45,19 @@ class StatsModelLinearRiskFactorModel:
     def __init__(self, regression_model, log_transform=False):
         self.parameters = regression_model._coefficients
         self.standard_errors = regression_model._coefficient_standard_errors
-        self.residual_mean = regression_model._residual_mean
-        self.residual_standard_deviation = regression_model._residual_standard_deviation
         self.log_transform = log_transform
         self.argument_transforms = get_all_argument_transforms(self.parameters.keys())
+        if (
+            hasattr(regression_model, "_residual_mean")
+            and hasattr(regression_model, "_residual_standard_deviation")
+        ):
+            self.residual_mean = regression_model._residual_mean
+            self.residual_standard_deviation = regression_model._residual_standard_deviation
 
     def draw_from_residual_distribution(self):
+        if not hasattr(self, "residual_mean") and hasattr(self, "residual_standard_deviation"):
+            raise RuntimeError("Cannot draw from residual distribution: model does not have"
+                               " residual information")
         return np.random.normal(
             loc=self.residual_mean,
             scale=self.residual_standard_deviation,

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -38,7 +38,7 @@ def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, Lis
     param_transforms = {}
     for param_name in parameter_names:
         prop_name, transforms = get_argument_transforms(param_name)
-        if transforms:
+        if param_name.casefold() != prop_name:
             param_transforms[param_name] = (prop_name, transforms)
     return param_transforms
 

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -96,7 +96,7 @@ def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, Lis
     """Return transform functions for each model parameter, if any"""
     param_transforms = {}
     for param_name in parameter_names:
-        prop_name, transforms = get_argument_transforms_recursive(param_name)
+        prop_name, transforms = get_argument_transforms(param_name)
         if param_name.casefold() != prop_name:
             param_transforms[param_name] = (prop_name, transforms)
     return param_transforms

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -1,81 +1,9 @@
 from functools import reduce
-from typing import Callable, Dict, Iterable, List, Tuple
-import re
 import numpy as np
-from mcm.model_argument_transform import (
-    base_transform,
-    IndicatorTransform,
-    log_transform,
-    mean_transform,
-    square_transform,
-)
+from mcm.model_argument_transform import get_all_argument_transforms
 
 # TODO: this class needs to be renamed. its no longer interfacing with statsmodel
 # conceptually, what it does now is bridge the regression model and the person
-
-
-categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
-categorical_param_name_regex = re.compile(categorical_param_name_pattern)
-
-
-def get_argument_transforms(
-    parameter_name: str,
-    max_num_transforms: int = 10,
-) -> Tuple[str, List[Callable]]:
-    trimmed_param_name = parameter_name
-    prop_transforms = []
-    reached_base_case = False
-    for _ in range(max_num_transforms):
-        folded_param_name = trimmed_param_name.casefold()
-        categorical_match = categorical_param_name_regex.match(parameter_name)
-        if categorical_match is not None:
-            expected_prop_name = categorical_match['propname']
-            matching_categorical_value = int(categorical_match['matchingval'])
-            prop_transforms.append(IndicatorTransform(matching_categorical_value))
-            reached_base_case = True
-            break
-        elif folded_param_name.startswith("log"):
-            trimmed_param_name = trimmed_param_name[len("log"):]
-            prop_transforms.append(log_transform)
-        elif folded_param_name.startswith("mean"):
-            trimmed_param_name = trimmed_param_name[len("mean"):]
-            prop_transforms.append(mean_transform)
-        elif folded_param_name.startswith("square"):
-            trimmed_param_name = trimmed_param_name[len("square"):]
-            prop_transforms.append(square_transform)
-        elif folded_param_name.startswith("base"):
-            trimmed_param_name = trimmed_param_name[len("base"):]
-            prop_transforms.append(base_transform)
-        elif folded_param_name.startswith("lag"):
-            trimmed_param_name = trimmed_param_name[len("lag"):]
-            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
-            # no transform: identity
-            reached_base_case = True
-            break
-        else:
-            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
-            # no transform: identity
-            reached_base_case = True
-            break
-    if not reached_base_case:
-        raise RuntimeError(
-            f"Error occurred while parsing parameter name ('{parameter_name}') for model argument"
-            f" transforms: exceeded maximum number of iterations ({max_num_transforms}) without"
-            " reaching a base case.",
-            parameter_name,
-            max_num_transforms,
-        )
-    return (expected_prop_name, reversed(prop_transforms))
-
-
-def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Callable]]:
-    """Return transform functions for each model parameter, if any"""
-    param_transforms = {}
-    for param_name in parameter_names:
-        prop_name, transforms = get_argument_transforms(param_name)
-        if param_name.casefold() != prop_name:
-            param_transforms[param_name] = (prop_name, transforms)
-    return param_transforms
 
 
 class StatsModelLinearRiskFactorModel:

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -10,6 +10,56 @@ categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\
 categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 
+def get_argument_transforms(
+    parameter_name: str,
+    max_num_transforms: int = 10
+) -> Tuple[str, List[Callable]]:
+    trimmed_param_name = parameter_name
+    prop_transforms = []
+    reached_base_case = False
+    for _ in range(max_num_transforms):
+        folded_param_name = trimmed_param_name.casefold()
+        categorical_match = categorical_param_name_regex.match(parameter_name)
+        if categorical_match is not None:
+            expected_prop_name = categorical_match['propname']
+            matching_categorical_value = int(categorical_match['matchingval'])
+            prop_transforms.append(lambda v: 1 if v == matching_categorical_value else 0)
+            reached_base_case = True
+            break
+        elif folded_param_name.startswith("log"):
+            trimmed_param_name = trimmed_param_name[len("log"):]
+            prop_transforms.append(lambda v: np.log(v))
+        elif folded_param_name.startswith("mean"):
+            trimmed_param_name = trimmed_param_name[len("mean"):]
+            prop_transforms.append(lambda v: np.array(v).mean())
+        elif folded_param_name.startswith("square"):
+            trimmed_param_name = trimmed_param_name[len("square"):]
+            prop_transforms.append(lambda v: v ** 2)
+        elif folded_param_name.startswith("base"):
+            trimmed_param_name = trimmed_param_name[len("base"):]
+            prop_transforms.append(lambda v: v[0])
+        elif folded_param_name.startswith("lag"):
+            trimmed_param_name = trimmed_param_name[len("lag"):]
+            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
+            # no transform: identity
+            reached_base_case = True
+            break
+        else:
+            expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]
+            # no transform: identity
+            reached_base_case = True
+            break
+    if not reached_base_case:
+        raise RuntimeError(
+            f"Error occurred while parsing parameter name ('{parameter_name}') for model argument"
+            f" transforms: exceeded maximum number of iterations ({max_num_transforms}) without"
+            " reaching a base case.",
+            parameter_name,
+            max_num_transforms,
+        )
+    return (expected_prop_name, reversed(prop_transforms))
+
+
 def get_argument_transforms_recursive(parameter_name: str) -> Tuple[str, List[Callable]]:
     folded_param_name = parameter_name.casefold()
     categorical_match = categorical_param_name_regex.match(parameter_name)


### PR DESCRIPTION
This PR separates the logic that transforms model arguments for `StatsModelLinearRiskFactorModel` based on parameter name prefixes, making it more comprehensible and shareable. This feature enabled quick, simple changes to Person properties that were passed to models for risk factor and outcome evaluation, which made it easy to include new models, so it made sense to make it an official, shareable thing.

Transforms (at the moment, anyway) are simple: they're callables that take one value and return another, possibly to another transform. Which callables are applied and in which order is determined by prefixes attached to the model parameter name. The core of this logic lives in [`get_argument_transforms`](https://github.com/jburke5/mcm/compare/add-model-argument-transforms#diff-1ccc851e3312f2e3662078e91dee5f6dR55).

I wasn't sure whether or not this was ready for PR, but I know that it's almost certainly clearer than the current implementation and is definitely faster than the current one, so I didn't want to hold onto it for any longer.