### PR TITLE
Class-based transforms

### DIFF
--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from copy import copy
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 import re
 
 import numpy as np

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta, abstractmethod
 from copy import copy
 from typing import Callable, Dict, Iterable, List, Tuple
 import re
@@ -7,6 +8,14 @@ import numpy as np
 
 categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\]]+)\]"
 categorical_param_name_regex = re.compile(categorical_param_name_pattern)
+
+
+class BaseTransform(metaclass=ABCMeta):
+    """ABC/interface definition for model argument transforms."""
+
+    @abstractmethod
+    def apply(self, value):
+        raise NotImplementedError()
 
 
 class IndicatorTransform:

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -18,7 +18,7 @@ class BaseTransform(metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class IndicatorTransform:
+class IndicatorTransform(BaseTransform):
     """
     Transform that returns 1 if value matches; else 0.
 
@@ -33,6 +33,9 @@ class IndicatorTransform:
         return self._matching_value
 
     def __call__(self, value):
+        return self.apply(value)
+
+    def apply(self, value):
         return 1 if value == self._matching_value else 0
 
     def __eq__(self, other):

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -11,7 +11,7 @@ categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 
 class BaseTransform(metaclass=ABCMeta):
-    """ABC/interface definition for model argument transforms."""
+    """Interface definition for model argument transforms."""
 
     @abstractmethod
     def apply(self, value):

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -84,16 +84,16 @@ def get_argument_transforms(
             break
         elif folded_param_name.startswith("log"):
             trimmed_param_name = trimmed_param_name[len("log"):]
-            prop_transforms.append(log_transform)
+            prop_transforms.append(LogTransform())
         elif folded_param_name.startswith("mean"):
             trimmed_param_name = trimmed_param_name[len("mean"):]
-            prop_transforms.append(mean_transform)
+            prop_transforms.append(MeanTransform())
         elif folded_param_name.startswith("square"):
             trimmed_param_name = trimmed_param_name[len("square"):]
-            prop_transforms.append(square_transform)
+            prop_transforms.append(SquareTransform())
         elif folded_param_name.startswith("base"):
             trimmed_param_name = trimmed_param_name[len("base"):]
-            prop_transforms.append(base_transform)
+            prop_transforms.append(FirstElementTransform())
         elif folded_param_name.startswith("lag"):
             trimmed_param_name = trimmed_param_name[len("lag"):]
             expected_prop_name = trimmed_param_name[0].casefold() + trimmed_param_name[1:]

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -42,24 +42,28 @@ class IndicatorTransform(AbstractBaseTransform):
         return False
 
 
-def log_transform(value):
+class LogTransform(AbstractBaseTransform):
     """Returns the log (one or many) of the given value."""
-    return np.log(value)
+    def apply(self, value):
+        return np.log(value)
 
 
-def mean_transform(value):
+class MeanTransform(AbstractBaseTransform):
     """Returns the mean of the given value."""
-    return np.array(value).mean()
+    def apply(self, value):
+        return np.array(value).mean()
 
 
-def square_transform(value):
+class SquareTransform(AbstractBaseTransform):
     """Returns the square (one or many) of the given value."""
-    return value ** 2
+    def apply(self, value):
+        return value ** 2
 
 
-def base_transform(value):
-    """Returns the base (i.e., first) element of the given value."""
-    return value[0]
+class FirstElementTransform(AbstractBaseTransform):
+    """Returns the first element of the given value."""
+    def apply(self, value):
+        return value[0]
 
 
 def get_argument_transforms(

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -12,7 +12,6 @@ categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 class BaseTransform(metaclass=ABCMeta):
     """Interface definition for model argument transforms."""
-
     @abstractmethod
     def apply(self, value):
         raise NotImplementedError()
@@ -27,7 +26,6 @@ class IndicatorTransform(BaseTransform):
 
     matching_value should be either a primitive or a `copy`-able container of primitives.
     """
-
     def __init__(self, matching_value):
         self._matching_value = copy(matching_value)
 

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -10,7 +10,7 @@ categorical_param_name_pattern = r"^(?P<propname>[^\[]+)\[T\.(?P<matchingval>[^\
 categorical_param_name_regex = re.compile(categorical_param_name_pattern)
 
 
-class BaseTransform(metaclass=ABCMeta):
+class AbstractBaseTransform(metaclass=ABCMeta):
     """Interface definition for model argument transforms."""
     @abstractmethod
     def apply(self, value):
@@ -20,7 +20,7 @@ class BaseTransform(metaclass=ABCMeta):
         return self.apply(value)
 
 
-class IndicatorTransform(BaseTransform):
+class IndicatorTransform(AbstractBaseTransform):
     """
     Transform that returns 1 if value matches; else 0.
 

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -16,9 +16,6 @@ class AbstractBaseTransform(metaclass=ABCMeta):
     def apply(self, value):
         raise NotImplementedError()
 
-    def __call__(self, value):
-        return self.apply(value)
-
 
 class IndicatorTransform(AbstractBaseTransform):
     """

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from copy import copy
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Callable, Dict, Iterable, List, Tuple, TypeVar
 import re
 
 import numpy as np
@@ -66,10 +66,13 @@ class FirstElementTransform(AbstractBaseTransform):
         return value[0]
 
 
+Transform = AbstractBaseTransform
+
+
 def get_argument_transforms(
     parameter_name: str,
     max_num_transforms: int = 10,
-) -> Tuple[str, List[Callable]]:
+) -> Tuple[str, List[Transform]]:
     trimmed_param_name = parameter_name
     prop_transforms = []
     reached_base_case = False
@@ -116,7 +119,7 @@ def get_argument_transforms(
     return (expected_prop_name, reversed(prop_transforms))
 
 
-def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Callable]]:
+def get_all_argument_transforms(parameter_names: Iterable[str]) -> Dict[str, List[Transform]]:
     """Return transform functions for each model parameter, if any"""
     param_transforms = {}
     for param_name in parameter_names:

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from copy import copy
-from typing import Callable, Dict, Iterable, List, Tuple, TypeVar
+from typing import Callable, Dict, Iterable, List, Tuple
 import re
 
 import numpy as np

--- a/mcm/model_argument_transform.py
+++ b/mcm/model_argument_transform.py
@@ -17,6 +17,9 @@ class BaseTransform(metaclass=ABCMeta):
     def apply(self, value):
         raise NotImplementedError()
 
+    def __call__(self, value):
+        return self.apply(value)
+
 
 class IndicatorTransform(BaseTransform):
     """
@@ -31,9 +34,6 @@ class IndicatorTransform(BaseTransform):
     @property
     def matching_value(self):
         return self._matching_value
-
-    def __call__(self, value):
-        return self.apply(value)
 
     def apply(self, value):
         return 1 if value == self._matching_value else 0

--- a/mcm/statsmodel_linear_risk_factor_model.py
+++ b/mcm/statsmodel_linear_risk_factor_model.py
@@ -43,7 +43,7 @@ class StatsModelLinearRiskFactorModel:
             else:
                 prop_name, transforms = self.argument_transforms[coeff_name]
                 prop_value = getattr(person, f"_{prop_name}")
-                model_argument = reduce(lambda v, f: f(v), transforms, prop_value)
+                model_argument = reduce(lambda v, t: t.apply(v), transforms, prop_value)
             if isinstance(model_argument, list) or isinstance(model_argument, np.ndarray):
                 model_argument = model_argument[-1]
             linearPredictor += coeff_val * model_argument


### PR DESCRIPTION
Follow-up on #6: convert all transforms to classes. This should make implementing new transforms and referencing existing ones easier because you don't have ask whether a transform is a class or a function or potentially consider the entire class of `Callable`s. This should also provide the basis to check that the inputs/outputs of transforms match before running the simulation proper, preventing runtime errors.

I'm not 100% happy with classes that don't have state, but the scoping and consistency added by making these classes outweighs that for me.